### PR TITLE
Add Death Screen and Restart/Quit Flow

### DIFF
--- a/docs/HOW_TO_PLAY.md
+++ b/docs/HOW_TO_PLAY.md
@@ -6,6 +6,8 @@
 python main.py
 ```
 
+You can restart endlessly without closing the program.
+
 ## Controls
 
 ### Movement
@@ -76,13 +78,17 @@ If you can’t, it’s already here.
 ## Objective
 
 **Escape the dungeon.**  
+*(Death is not the end. It just loops.)*  
 *(There is no evidence the **End** exists.)*
 
 1. Keep going down. Stopping is not an option.
-2. Trust the exit (**E**), if you want
+2. Trust the exit (**E**), if you want.
 3. Watch your **HP** and **SAN**. They are the only proof you still exist.
 4. Hoard anything that makes it hurt less.
 5. Run from everything else. It knows where you are.
+
+The game does not want you to win.  
+It wants you to **continue**.
 
 ## Survival Tips
 
@@ -113,6 +119,10 @@ Low sanity causes:
 
 At 0 SAN, the game stops pretending to be fair.
 
+The UI still works.  
+The rules still apply.  
+Only **you** stop understanding them.
+
 ---
 
 ### Lighting
@@ -124,7 +134,10 @@ At 0 SAN, the game stops pretending to be fair.
   - Full illumination around you  
 
 Light reveals the dungeon.  
-It also tells the dungeon where you are.
+It also reveals **you**.
+
+Nothing in the dark was lost.  
+It was only waiting to be noticed.
 
 ---
 
@@ -147,14 +160,16 @@ They also create new ones.
 - Predictable pattern  
 
 It wants you dead.  
-It’s honest about it.
+It doesn’t know why.  
+It doesn’t need to.
 
 **Stalker (S)** - High threat  
 - Hunts intelligently  
 - Drains sanity just by seeing you  
 - Dangerous in light  
 
-If you see it, it already knows where you are.
+If you see it, it already knows where you are.  
+If you don’t, it’s closer.
 
 **Ambusher (#)** - Extreme threat  
 - Hides in darkness  
@@ -163,18 +178,33 @@ If you see it, it already knows where you are.
 - Use light to detect  
 - If you see a wall blinking, it's already too late  
 
-That wall was never a wall.
+That wall was never a wall.  
+It was a decision you made earlier.
 
 ---
 
 ## Game Over
 
-The game ends when:
-- Your **HP** reaches 0 (enemy contact, starvation)  
-- You willingly quit with Ctrl+C  
+When your **HP** or **SAN** reaches 0, the game does not immediately exit.
 
-There is no victory screen.  
-Only quieter deaths.
+Instead, a **death screen** is shown.
+
+### Death Screen
+Displays:
+- Title message: `YOU ARE STILL HERE`
+- Cause of death
+- World seed of the run
+- A reminder that the world will not change without you
+
+### Options
+- **R** → Restart  
+- **Q / ESC** → Quit  
+
+Restarting does not fix what happened.  
+It only proves that it can happen again.
+
+Quitting does not end the game.  
+It only ends your memory of it.
 
 ---
 
@@ -189,3 +219,6 @@ Only quieter deaths.
 The deeper you go,  
 the less the game explains,  
 and the more it *expects you to already know*.
+
+Which is strange,  
+because you don’t remember learning any of this.

--- a/docs/MECHANICS.md
+++ b/docs/MECHANICS.md
@@ -22,7 +22,7 @@ Dark Floor is a terminal-based roguelike game. This document details all game me
 ### Health (HP)
 - **Starting HP:** 500
 - **Decrement:** -1 per movement action
-- **Game Over:** Player dies when HP reaches 0
+- **Game Over:** Player dies when HP reaches 0 and death screen is shown
 - **Death Message:** Customizable when HP <= 0
 
 ### Sanity (SAN)
@@ -31,6 +31,7 @@ Dark Floor is a terminal-based roguelike game. This document details all game me
 - **Fog Penalty:** -0.02 sanity when standing in fog
 - **Restoration:** Items can restore sanity
 - **Status:** Affects player color when damaged
+- **Game Over:** Player dies when SAN reaches 0 and death screen is shown
 
 ### Color System
 - **Default Color:** 8 (white)
@@ -240,7 +241,38 @@ Emitted by entities during actions:
 
 ---
 
+## Death Screen
+
+When the player dies (HP ≤ 0 or SAN ≤ 0), the game enters a death screen state.
+
+### Display
+- Title message: `YOU ARE STILL HERE`
+- Cause of death
+- World seed of the run
+- Flavor text
+
+### Controls
+- **R** → Restart game with a new run
+- **Q / ESC** → Quit game
+
+The game is fully paused while on this screen.
+
+---
+
 ## Game Loop
+
+The game runs in a single-session loop and returns control on death.
+The launcher is responsible for restarting or exiting.
+
+### Restart Flow
+
+1. Player dies  
+2. Death screen is shown  
+3. Player presses:
+   - `R` → Game state resets and a new run starts  
+   - `Q` → Program exits cleanly  
+
+No process restart is required.
 
 ### Frame Rate
 - **Target FPS:** 10 frames per second
@@ -314,6 +346,8 @@ Line H+3: [Clear] A heavy thud to the East
 ### Usage
 - Seed is displayed on game startup and in the HUD.
 - Seed is printed to terminal for debugging and sharing runs.
+- Seed is also displayed on the death screen.
+- Restart generates a new derived seed.
 
 ### Determinism
 - All RNG-dependent systems derive from the seed:

--- a/main.py
+++ b/main.py
@@ -18,12 +18,23 @@ def setup_and_run():
     print("Dark Floor")
     print("=" * 40)
     print(f"Version: {VERSION}")
-    print(f"Seed: {SEED}")
+    print(f"Base Seed: {SEED}")
     print("Loading game...")
     time.sleep(1.5)
-    
+
+    run_id = 0
+
     try:
-        curses.wrapper(main)
+        while True:
+            rng_seed = f"{SEED}-{run_id}"
+            print(f"Run seed: {rng_seed}")
+            result = curses.wrapper(main, rng_seed)
+
+            if result == "quit":
+                break
+
+            run_id += 1
+
     except KeyboardInterrupt:
         print("\nGame interrupted by user.")
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -21,9 +21,7 @@ def setup_and_run():
     print(f"Base Seed: {SEED}")
     print("Loading game...")
     time.sleep(1.5)
-
     run_id = 0
-
     try:
         while True:
             rng_seed = f"{SEED}-{run_id}"
@@ -32,7 +30,6 @@ def setup_and_run():
 
             if result == "quit":
                 break
-
             run_id += 1
 
     except KeyboardInterrupt:

--- a/src/help.txt
+++ b/src/help.txt
@@ -1,0 +1,41 @@
+--- DARK FLOOR: SURVIVAL GUIDE ---
+
+[CONTROLS]
+WASD   : Move / Face Direction
+1-5    : Select Inventory Slot
+E      : Use / Toggle Selected Item
+H      : Close Help Menu
+
+[HUD]
+FL     : Current Floor (Goal: 0)
+HP     : Health (Move/Hits drain this)
+SAN    : Sanity (Fog/Stalkers drain this)
+[*]    : Item is active/toggled on
+
+[SYMBOLS]
+@ Player  |  # Wall    |  . Floor   |  E Exit
++ Water   |  * R-Water |  v Vitality|  B Bomb
+F Flash   |  L Lantern |  ? Fog     |  X Chaser
+S Stalker |  A Ambusher|            |
+
+[ENEMIES]
+X - Chaser  : Aggressive. Chases when close.
+S - Stalker : Drains SAN on sight. Hunts slowly.
+A - Ambusher: Camouflaged as '#'. One-hit kill.
+
+[RESOURCES]
+Water (+)   : +100 HP
+R-Water (*) : +200 HP, +10 SAN
+Vitality (v): +10 SAN
+Flash (F)   : 90° Light Cone (Long range)
+Lantern (L) : 360° Light Circle (Short range)
+Bomb (B)    : Destroys walls and enemies in 3x3
+
+[NOTES]
+- Every step costs 1 HP. 
+- Standing in Fog (?) rapidly drains SAN.
+- Light reveals items... and attracts 'them'.
+- Death (0 HP/SAN) is a loop. Seed is saved.
+
+The deeper you go, the less the world remembers you.
+-------------------------------------------------------


### PR DESCRIPTION
# Add Death Screen and Restart/Quit Flow

## Summary
This PR introduces a dedicated **death screen** and integrates it with a **launcher-managed restart system**.  
The game no longer handles restarts internally; instead, it returns control to the launcher, which manages run recycling and seed progression.

## Changes
- Added `death_screen()` UI with:
  - Title message: `YOU ARE STILL HERE`
  - Cause of death
  - Current run seed
  - Restart / Quit options
- Refactored `darkfloor.main()` to:
  - Return `"restart"` or `"quit"` instead of exiting.
- Implemented outer run loop in `main.py` launcher:
  - Handles multiple runs in a single process.
  - Increments `run_id` and derives new seed each restart.
- Death no longer terminates the program directly.

## Technical Notes
- Each run uses a derived seed:
  - `rng_seed = f"{BASE_SEED}-{run_id}"`
- On death:
  - `darkfloor.main()` calls `death_screen()` and returns a result.
  - Launcher decides whether to restart or exit.
- Curses session is fully recreated per run via `curses.wrapper`.

## Gameplay Impact
- Introduces true **run-based gameplay loop**.
- Enables infinite replays without restarting the program.
- Makes seeds explicit and reproducible per run.
- Strengthens horror tone with persistent end-state instead of hard exit.
